### PR TITLE
Fix:checkAuth呼び出し時にawaitを使用する

### DIFF
--- a/frontend/src/app/contexts/AuthContext.tsx
+++ b/frontend/src/app/contexts/AuthContext.tsx
@@ -25,7 +25,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setLoading(true);
       try {
         await web3auth.initModal();
-        checkAuth();
+        await checkAuth();
       } catch (error) {
         console.error('Error initializing auth:', error);
       } finally {


### PR DESCRIPTION
## 概要
SyntaxError: Invalid or unexpected token :3000/_next/static/c…s/app/layout.js:279の解消

## 詳細
非同期処理であるcheckAuth呼び出し時にawaitを使用していないことによる初期レンダリングエラーの解消