### PR TITLE
AuthContext内でweb3authの初期化完了有無を保持する

### DIFF
--- a/frontend/src/app/types/auth.ts
+++ b/frontend/src/app/types/auth.ts
@@ -10,4 +10,5 @@ export interface AuthContextType {
   user: User | null;
   login: (method: AuthMethod) => Promise<void>;
   logout: () => Promise<void>;
+  isInitialized: Boolean;
 }


### PR DESCRIPTION
## 解消するエラー
`web3auth.initModal();`でweb3authの初期化をするが、処理に時間がかかるため`WalletInitializationError: Wallet is not ready yet, Adapter is already initialized`が発生する場合がある

## 解消法
初期化状態を管理するisInitialiedを実装し、初期化が終わっていないときはローディングを表示する