### PR TITLE
Pinata処理をAPIで行う

### DIFF
--- a/frontend/src/app/api/v1/pinata/nft-metadata/route.ts
+++ b/frontend/src/app/api/v1/pinata/nft-metadata/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import axios from 'axios';
+
+const PINATA_API_KEY = process.env.PINATA_API_KEY;
+const PINATA_SECRET_API_KEY = process.env.PINATA_SECRET_API_KEY;
+const PINATA_API_URL = 'https://api.pinata.cloud';
+
+export async function POST(request: Request) {
+  try {
+    const { imageHash, location } = await request.json();
+    const metadata = {
+      name: `${location.name} Visit`,
+      description: `This NFT commemorates your visit to ${location.name} on ${new Date().toDateString()}.`,
+      image: imageHash,
+      attributes: [
+        {
+          trait_type: "Location",
+          value: location.name
+        },
+        {
+          trait_type: "Minted Date",
+          value: new Date().toISOString()
+        }
+      ]
+    };
+
+    const response = await axios.post(`${PINATA_API_URL}/pinning/pinJSONToIPFS`, metadata, {
+      headers: {
+        pinata_api_key: PINATA_API_KEY,
+        pinata_secret_api_key: PINATA_SECRET_API_KEY,
+      },
+    });
+
+    return NextResponse.json({ ipfsHash: `ipfs://${response.data.ipfsHash}` });
+  } catch (error) {
+    console.error('Error in Pinata NFT Metadata API route:', error);
+    return NextResponse.json({ error: 'An error occurred while processing your request' }, { status: 500 });
+  }
+}

--- a/frontend/src/lib/pinata.ts
+++ b/frontend/src/lib/pinata.ts
@@ -5,6 +5,6 @@ export async function generateAndUploadNFTMetaData(
   imageHash: string,
   location: LocationWithThumbnailAndDistance
 ) {
-  const response = await axios.post('/api/vi/pinata/nft-metadata', {imageHash, location});
+  const response = await axios.post('/api/v1/pinata/nft-metadata', {imageHash, location});
   return response.data.ipfsHash
 }

--- a/frontend/src/lib/pinata.ts
+++ b/frontend/src/lib/pinata.ts
@@ -1,46 +1,10 @@
 import { LocationWithThumbnailAndDistance } from '@/app/types/location';
 import axios from 'axios';
 
-const PINATA_API_KEY  = process.env.NEXT_PUBLIC_PINATA_API_KEY;
-const PINATA_SECRET_API_KEY  = process.env.NEXT_PUBLIC_PINATA_SECRET_API_KEY;
-
-if (!PINATA_API_KEY || !PINATA_SECRET_API_KEY) {
-  throw new Error('Pinata API keys are not set in the environment variables.');
-}
-
-const pinataApiUrl = 'https://api.pinata.cloud';
-
-export async function uploadJsonToPinata(json: Object): Promise<string> {
-  const response = await axios.post(`${pinataApiUrl}/pinning/pinJSONToIPFS`, json, {
-    headers: {
-      pinata_api_key: PINATA_API_KEY,
-      pinata_secret_api_key: PINATA_SECRET_API_KEY,
-    },
-  });
-
-  return `ipfs://${response.data.IpfsHash}`
-}
-
 export async function generateAndUploadNFTMetaData(
   imageHash: string,
-  location: LocationWithThumbnailAndDistance,
-): Promise<string> {
-  const date = new Date();
-  const metadata = {
-    name: `${location.name} Visit`,
-    description: `This NFT commemorates your visit to ${location.name} on ${date.toDateString()}.`,
-    image: imageHash,
-    attributes: [
-      {
-        trait_type: "Location",
-        value: location.name
-      },
-      {
-        trait_type: "Minted Date",
-        value: new Date().toISOString()
-      }
-    ]
-  };
-
-  return uploadJsonToPinata(metadata);
+  location: LocationWithThumbnailAndDistance
+) {
+  const response = await axios.post('/api/vi/pinata/nft-metadata', {imageHash, location});
+  return response.data.ipfsHash
 }


### PR DESCRIPTION
## 概要
Pinata処理をクライアントサイドで行うと、API_KEY流失の危険性があるため、サーバーサイドで実行