### PR TITLE
観光地詳細画面でユーザと観光地までの距離を表示する

### DIFF
--- a/frontend/src/app/actions/totalNFTs.ts
+++ b/frontend/src/app/actions/totalNFTs.ts
@@ -26,7 +26,6 @@ function getUserIdFromToken(): string | null {
 
 // SupabaseからユーザーのNFT総数を取得する関数
 export async function getUserData() {
-	console.log('getUserData called')
   const userId = getUserIdFromToken()
   if (!userId) {
     throw new Error('Unauthorized')
@@ -50,7 +49,6 @@ export async function getUserData() {
 
 // ユーザーのNFT総数を更新する関数(呼ばれるたびにdashboardのユーザーNFT総数を再検証)
 export async function updateUserData(newTotalNFTs: number) {
-	console.log('updateUserData called with:', newTotalNFTs)
   const userId = getUserIdFromToken()
   if (!userId) {
     throw new Error('Unauthorized')

--- a/frontend/src/app/components/LocationDistance.tsx
+++ b/frontend/src/app/components/LocationDistance.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { MapPin } from 'lucide-react'
+import React from 'react'
+import { useLocations } from '@/hooks/useLocations'
+
+export const LocationDistance: React.FC<{ lat: number, lon: number }> = ({ lat, lon }) =>{
+	const { userLocation } = useLocations()
+
+	const calculateDistance = (lat1: number | null, lon1: number | null, lat2: number, lon2: number): number => {
+		if (lat1 === null || lon1 === null) {
+			return 0
+		}
+		console.log(lat1, lon1, lat2, lon2)
+		const R = 6371 // Earth's radius in km
+		const dLat = (lat2 - lat1) * Math.PI / 180
+		const dLon = (lon2 - lon1) * Math.PI / 180
+		const a = 	
+			Math.sin(dLat/2) * Math.sin(dLat/2) +
+			Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) * 
+			Math.sin(dLon/2) * Math.sin(dLon/2)
+		const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a))
+		const distance = R * c
+		return Number(distance.toFixed(1))
+	}
+
+  return (
+		<span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-700 text-gray-200">
+			<MapPin className="h-4 w-4 mr-1 text-green-400" />
+			{calculateDistance(userLocation.lat, userLocation.lon, lat, lon)} km
+		</span>
+  )
+}

--- a/frontend/src/app/components/LocationDistance.tsx
+++ b/frontend/src/app/components/LocationDistance.tsx
@@ -11,7 +11,6 @@ export const LocationDistance: React.FC<{ lat: number, lon: number }> = ({ lat, 
 		if (lat1 === null || lon1 === null) {
 			return 0
 		}
-		console.log(lat1, lon1, lat2, lon2)
 		const R = 6371 // Earth's radius in km
 		const dLat = (lat2 - lat1) * Math.PI / 180
 		const dLon = (lon2 - lon1) * Math.PI / 180

--- a/frontend/src/app/components/LocationDistance.tsx
+++ b/frontend/src/app/components/LocationDistance.tsx
@@ -25,7 +25,7 @@ export const LocationDistance: React.FC<{ lat: number, lon: number }> = ({ lat, 
 	}
 
   return (
-		<span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-700 text-gray-200">
+		<span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-700 text-green-400">
 			<MapPin className="h-4 w-4 mr-1 text-green-400" />
 			{calculateDistance(userLocation.lat, userLocation.lon, lat, lon)} km
 		</span>

--- a/frontend/src/app/spots/[slug]/page.tsx
+++ b/frontend/src/app/spots/[slug]/page.tsx
@@ -6,6 +6,8 @@ import Header from '../../components/Header'
 import { getLocationBySlug } from '@/lib/getLocations'
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
+import { LocationDistance } from '@/app/components/LocationDistance'
+import { Suspense } from 'react'
 
 export default async function TouristSpotDetail({ params }: { params: { slug: string } }) {
   const location = await getLocationBySlug(params.slug);
@@ -39,6 +41,14 @@ export default async function TouristSpotDetail({ params }: { params: { slug: st
                   <Mail className="h-4 w-4 mr-1" />
                   {location.postal_code}
                 </span>
+								<Suspense fallback={
+									<span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-700 text-gray-200">
+									<MapPin className="h-4 w-4 mr-1" />
+									 Loading...
+								</span>
+								}>
+									<LocationDistance lat={location.latitude} lon={location.longitude} />
+								</Suspense>
               </div>
             </div>
           </div>

--- a/frontend/src/app/spots/page.tsx
+++ b/frontend/src/app/spots/page.tsx
@@ -16,7 +16,7 @@ export default async function TouristSpots() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
           {locations.map((location) => (
             <Link href={`/spots/${location.slug}`} key={location.id}>
-              <Card key={location.id} className="bg-gray-800 border-gray-700 overflow-hidden rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-blue-500/20 group">
+              <Card className="bg-gray-800 border-gray-700 overflow-hidden rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-blue-500/20 group">
                 <div className="relative h-48 overflow-hidden">
                   <Image
                     src={location.thumbnail || '/images/default-thumbnail.jpg'}

--- a/frontend/src/app/spots/page.tsx
+++ b/frontend/src/app/spots/page.tsx
@@ -1,21 +1,13 @@
-'use client'
-
 import Image from 'next/image'
 import { Card, CardContent } from "@/components/ui/card"
 import { MapPin, Info } from 'lucide-react'
 import { Footer } from '../components/Footer'
 import Header from '../components/Header'
-import { Loading } from '../components/Loading'
-import { useLocations } from '@/hooks/useLocations'
-import { useRouter } from 'next/navigation'
+import { getLocations } from '@/lib/getLocations'
+import Link from 'next/link'
 
-export default function TouristSpots() {
-  const { locations, loading, distances } = useLocations()
-  const router = useRouter()
-
-  if (loading) {
-    return <Loading />;
-  }
+export default async function TouristSpots() {
+  const locations = await getLocations()
 
   return (
     <div className="flex flex-col min-h-screen bg-gradient-to-br from-gray-900 to-gray-800 text-white">
@@ -23,34 +15,31 @@ export default function TouristSpots() {
       <main className="flex-1 py-8 px-4">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
           {locations.map((location) => (
-            <Card key={location.id} onClick={() => router.push(`/spots/${location.slug}`)} className="bg-gray-800 border-gray-700 overflow-hidden rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-blue-500/20 group">
-              <div className="relative h-48 overflow-hidden">
-                <Image
-                  src={location.thumbnail || '/images/default-thumbnail.jpg'}
-                  alt={location.name}
-                  width={640}
-                  height={360}
-                  className="object-cover w-full h-48 transition-transform duration-300 group-hover:scale-110"
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-gray-900 to-transparent opacity-0 group-hover:opacity-70 transition-opacity duration-300" />
-              </div>
-              <CardContent className="p-4 relative">
-                <h3 className="text-xl font-semibold mb-2 text-blue-400 group-hover:text-blue-300 transition-colors duration-300">{location.name}</h3>
-                <div className="flex items-center text-gray-400 mb-1">
-                  <MapPin className="h-4 w-4 mr-1" />
-                  <span>{location.address}</span>
+            <Link href={`/spots/${location.slug}`} key={location.id}>
+              <Card key={location.id} className="bg-gray-800 border-gray-700 overflow-hidden rounded-lg transition-all duration-300 hover:shadow-lg hover:shadow-blue-500/20 group">
+                <div className="relative h-48 overflow-hidden">
+                  <Image
+                    src={location.thumbnail || '/images/default-thumbnail.jpg'}
+                    alt={location.name}
+                    width={640}
+                    height={360}
+                    className="object-cover w-full h-48 transition-transform duration-300 group-hover:scale-110"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-gray-900 to-transparent opacity-0 group-hover:opacity-70 transition-opacity duration-300" />
                 </div>
-                <div className="text-sm text-gray-500 mb-2">{location.postal_code}</div>
-                {distances[location.id] && (
-                  <div className="text-sm text-green-400">
-                    距離: {distances[location.id]} km
+                <CardContent className="p-4 relative">
+                  <h3 className="text-xl font-semibold mb-2 text-blue-400 group-hover:text-blue-300 transition-colors duration-300">{location.name}</h3>
+                  <div className="flex items-center text-gray-400 mb-1">
+                    <MapPin className="h-4 w-4 mr-1" />
+                    <span>{location.address}</span>
                   </div>
-                )}
-                <div className="absolute top-4 right-4 bg-blue-500 rounded-full p-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                  <Info className="h-4 w-4 text-white" />
-                </div>
-              </CardContent>
-            </Card>
+                  <div className="text-sm text-gray-500 mb-2">{location.postal_code}</div>
+                  <div className="absolute top-4 right-4 bg-blue-500 rounded-full p-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                    <Info className="h-4 w-4 text-white" />
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
           ))}
         </div>
       </main>

--- a/frontend/src/hooks/useLocations.ts
+++ b/frontend/src/hooks/useLocations.ts
@@ -1,12 +1,10 @@
 import { useState, useEffect } from "react";
-import { getLocations, getNearestLocations } from "@/lib/getLocations";
-import { Location, LocationWithThumbnailAndDistance } from "@/app/types/location";
+import { getNearestLocations } from "@/lib/getLocations";
+import { LocationWithThumbnailAndDistance } from "@/app/types/location";
 
 export const useLocations = (nearestCount: number = 3) => {
   const [userLocation, setUserLocation] = useState<{ lat: number | null; lon: number | null }>({ lat: null, lon: null })
-  const [locations, setLocations] = useState<(Location & { thumbnail: string | null })[]>([]);
   const [nearestLocations, setNearestLocations] = useState<LocationWithThumbnailAndDistance[]>([]);
-  const [distances, setDistances] = useState<{ [key: string]: number }>({});
   const [loading, setLoading] = useState(true);
 
   // ユーザの位置情報を監視
@@ -56,23 +54,6 @@ export const useLocations = (nearestCount: number = 3) => {
     }
   }, []);
 
-  // 全ての観光地を取得
-  useEffect(() => {
-    const fetchLocations = async () => {
-      setLoading(true);
-      try {
-        const fetchedLocations = await getLocations();
-        setLocations(fetchedLocations);
-      } catch (error) {
-        console.error('Failed to fetch locations:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchLocations();
-  }, []);
-
   // 最寄りの場所を取得
   useEffect(() => {
     const fetchNearestLocations = async () => {
@@ -91,30 +72,5 @@ export const useLocations = (nearestCount: number = 3) => {
     fetchNearestLocations();
   }, [userLocation.lat, userLocation.lon, nearestCount]);
 
-  useEffect(() => {
-    if (userLocation.lat !== null && userLocation.lon !== null) {
-      const newDistances: { [key: number]: number } = {}
-      locations.forEach(location => {
-        const distance = calculateDistance(userLocation.lat!, userLocation.lon!, location.latitude, location.longitude)
-        newDistances[location.id] = distance
-      })
-      setDistances(newDistances)
-    }
-  }, [userLocation, locations])
-
-
-  const calculateDistance = (lat1: number, lon1: number, lat2: number, lon2: number): number => {
-    const R = 6371 // Earth's radius in km
-    const dLat = (lat2 - lat1) * Math.PI / 180
-    const dLon = (lon2 - lon1) * Math.PI / 180
-    const a = 
-      Math.sin(dLat/2) * Math.sin(dLat/2) +
-      Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) * 
-      Math.sin(dLon/2) * Math.sin(dLon/2)
-    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a))
-    const distance = R * c
-    return Number(distance.toFixed(1))
-  }
-
-  return { userLocation, locations, nearestLocations, loading, distances };
+  return { userLocation, nearestLocations, loading };
 }


### PR DESCRIPTION
## 概要
詳細画面でサーバコンポーネントを維持しつつ、ユーザとの距離の箇所のみクライアントコンポーネントにする

## 詳細
- 観光地一覧において、ユーザとの距離を取得し続けるのは非効率なためサーバコンポーネントにして距離を表示しない
- 観光地詳細画面では、ユーザとの距離を示すことで、将来追加するNFT発行条件を視覚的にわかりやすくする

## /spots
<img width="1437" alt="スクリーンショット 2024-09-22 19 54 53" src="https://github.com/user-attachments/assets/e4c21447-9d27-4856-af87-f00725e181b1">

## /spots/[slug]
<img width="1439" alt="スクリーンショット 2024-09-22 19 55 04" src="https://github.com/user-attachments/assets/6a37e981-0e49-49a2-b20a-61f353fbad03">
