### PR TITLE
最寄りの観光地取得メソッドを無駄に呼び出さない

### DIFF
--- a/frontend/src/app/components/NearestNFTSpots.tsx
+++ b/frontend/src/app/components/NearestNFTSpots.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { Button } from "@/components/ui/button";
@@ -20,11 +20,22 @@ import { updateUserData } from '@/app/actions/totalNFTs';
 export const NearestNFTSpots: React.FC = () => {
   const { user } = useAuth();
   const { mintNFT } = useSmartContractInteractions();
-  const { nearestLocations, loading } = useLocations();
+  const { userLocation, fetchNearestLocations } = useLocations();
+  const [nearestLocations, setNearestLocations] = useState<LocationWithThumbnailAndDistance[]>([]);
   const [isMinting, setIsMinting] = useState(false);
   const [isMintingLocation, setIsMintingLocation] = useState<number>();
   const [progress, setProgress] = useState(0);
   const { toast } = useToast();
+
+  useEffect(() =>  {
+    const fetchLocations = async () => {
+      const locations: LocationWithThumbnailAndDistance[] | undefined = await fetchNearestLocations()
+      if (locations) {
+        setNearestLocations(locations)
+      }
+    }
+    fetchLocations()
+  }, [userLocation])
 
   const handleMintNFT = async (location: LocationWithThumbnailAndDistance) => {
     if (!user) {
@@ -75,10 +86,6 @@ export const NearestNFTSpots: React.FC = () => {
       setProgress(0)
     }
   };
-
-  if (loading) {
-    return <Loading />;
-  }
 
   return (
     <section>

--- a/frontend/src/hooks/useLocations.ts
+++ b/frontend/src/hooks/useLocations.ts
@@ -4,8 +4,6 @@ import { LocationWithThumbnailAndDistance } from "@/app/types/location";
 
 export const useLocations = (nearestCount: number = 3) => {
   const [userLocation, setUserLocation] = useState<{ lat: number | null; lon: number | null }>({ lat: null, lon: null })
-  const [nearestLocations, setNearestLocations] = useState<LocationWithThumbnailAndDistance[]>([]);
-  const [loading, setLoading] = useState(true);
 
   // ユーザの位置情報を監視
   useEffect(() => {
@@ -55,22 +53,16 @@ export const useLocations = (nearestCount: number = 3) => {
   }, []);
 
   // 最寄りの場所を取得
-  useEffect(() => {
-    const fetchNearestLocations = async () => {
-      if (userLocation.lat !== null && userLocation.lon !== null) {
-        setLoading(true);
-        try {
-          const fetchedNearestLocations = await getNearestLocations(userLocation.lat, userLocation.lon, nearestCount);
-          setNearestLocations(fetchedNearestLocations);
-        } catch (error) {
-          console.error('Failed to fetch nearest locations:', error);
-        } finally {
-          setLoading(false);
-        }
+  const fetchNearestLocations = async () => {
+    if (userLocation.lat !== null && userLocation.lon !== null) {
+      try {
+        const fetchedNearestLocations = await getNearestLocations(userLocation.lat, userLocation.lon, nearestCount);
+        return fetchedNearestLocations;
+      } catch (error) {
+        console.error('Failed to fetch nearest locations:', error);
       }
-    };
-    fetchNearestLocations();
-  }, [userLocation.lat, userLocation.lon, nearestCount]);
+    }
+  };
 
-  return { userLocation, nearestLocations, loading };
+  return { userLocation, fetchNearestLocations };
 }


### PR DESCRIPTION
## 概要
#60 

## 修正内容
最寄りの観光地を取得する`fetchLocations`メソッドの実行をカスタムフックではなく、最寄りの観光地を表示するコンポーネントで制御する
