### PR TITLE
NFT発行を観光地詳細画面からできるようにする

### DIFF
--- a/frontend/src/app/components/LocationDistance.tsx
+++ b/frontend/src/app/components/LocationDistance.tsx
@@ -8,7 +8,7 @@ import { LocationWithThumbnail } from '../types/location'
 
 export const LocationDistance: React.FC<LocationWithThumbnail> = ({ ...location }) => {
   const { userLocation } = useLocations();
-	const [distance, setDistance] = useState<number>(0);
+	const [distance, setDistance] = useState<number>();
 
 	useEffect(() => {
 		const calculatedDistance = calculateDistance(userLocation.lat, userLocation.lon, location.latitude, location.longitude);

--- a/frontend/src/app/components/LocationDistance.tsx
+++ b/frontend/src/app/components/LocationDistance.tsx
@@ -3,7 +3,6 @@
 import { MapPin } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
 import { useLocations } from '@/hooks/useLocations'
-import { Button } from '@/components/ui/button'
 import MintNFTButton from './mintNFTButton'
 import { LocationWithThumbnail } from '../types/location'
 

--- a/frontend/src/app/components/LocationDistance.tsx
+++ b/frontend/src/app/components/LocationDistance.tsx
@@ -1,12 +1,20 @@
 'use client'
 
 import { MapPin } from 'lucide-react'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useLocations } from '@/hooks/useLocations'
 import { Button } from '@/components/ui/button'
+import MintNFTButton from './mintNFTButton'
+import { LocationWithThumbnail } from '../types/location'
 
-export const LocationDistance: React.FC<{ lat: number; lon: number }> = ({ lat, lon }) => {
-  const { userLocation } = useLocations()
+export const LocationDistance: React.FC<LocationWithThumbnail> = ({ ...location }) => {
+  const { userLocation } = useLocations();
+	const [distance, setDistance] = useState<number>(0);
+
+	useEffect(() => {
+		const calculatedDistance = calculateDistance(userLocation.lat, userLocation.lon, location.latitude, location.longitude);
+		setDistance(calculatedDistance);
+	}, [userLocation]);
 
   const calculateDistance = (lat1: number | null, lon1: number | null, lat2: number, lon2: number): number => {
     if (lat1 === null || lon1 === null) {
@@ -28,11 +36,9 @@ export const LocationDistance: React.FC<{ lat: number; lon: number }> = ({ lat, 
     <>
       <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-700 text-green-400">
         <MapPin className="h-4 w-4 mr-1" />
-        {calculateDistance(userLocation.lat, userLocation.lon, lat, lon)} km
+        {distance} km
       </span>
-      <Button size="sm" className="bg-blue-600 hover:bg-blue-700 text-xs text-white">
-        GET NFT!
-      </Button>
+			{distance !== undefined && <MintNFTButton location={{ ...location, distance }} />}
     </>
   )
 }

--- a/frontend/src/app/components/LocationDistance.tsx
+++ b/frontend/src/app/components/LocationDistance.tsx
@@ -3,30 +3,36 @@
 import { MapPin } from 'lucide-react'
 import React from 'react'
 import { useLocations } from '@/hooks/useLocations'
+import { Button } from '@/components/ui/button'
 
-export const LocationDistance: React.FC<{ lat: number, lon: number }> = ({ lat, lon }) =>{
-	const { userLocation } = useLocations()
+export const LocationDistance: React.FC<{ lat: number; lon: number }> = ({ lat, lon }) => {
+  const { userLocation } = useLocations()
 
-	const calculateDistance = (lat1: number | null, lon1: number | null, lat2: number, lon2: number): number => {
-		if (lat1 === null || lon1 === null) {
-			return 0
-		}
-		const R = 6371 // Earth's radius in km
-		const dLat = (lat2 - lat1) * Math.PI / 180
-		const dLon = (lon2 - lon1) * Math.PI / 180
-		const a = 	
-			Math.sin(dLat/2) * Math.sin(dLat/2) +
-			Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) * 
-			Math.sin(dLon/2) * Math.sin(dLon/2)
-		const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a))
-		const distance = R * c
-		return Number(distance.toFixed(1))
-	}
+  const calculateDistance = (lat1: number | null, lon1: number | null, lat2: number, lon2: number): number => {
+    if (lat1 === null || lon1 === null) {
+      return 0
+    }
+    const R = 6371 // Earth's radius in km
+    const dLat = (lat2 - lat1) * Math.PI / 180
+    const dLon = (lon2 - lon1) * Math.PI / 180
+    const a = 
+      Math.sin(dLat/2) * Math.sin(dLat/2) +
+      Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) * 
+      Math.sin(dLon/2) * Math.sin(dLon/2)
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a))
+    const distance = R * c
+    return Number(distance.toFixed(1))
+  }
 
   return (
-		<span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-700 text-green-400">
-			<MapPin className="h-4 w-4 mr-1 text-green-400" />
-			{calculateDistance(userLocation.lat, userLocation.lon, lat, lon)} km
-		</span>
+    <>
+      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-700 text-green-400">
+        <MapPin className="h-4 w-4 mr-1" />
+        {calculateDistance(userLocation.lat, userLocation.lon, lat, lon)} km
+      </span>
+      <Button size="sm" className="bg-blue-600 hover:bg-blue-700 text-xs text-white">
+        GET NFT!
+      </Button>
+    </>
   )
 }

--- a/frontend/src/app/components/NearestNFTSpots.tsx
+++ b/frontend/src/app/components/NearestNFTSpots.tsx
@@ -5,27 +5,14 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { Progress } from "@/components/ui/progress";
 import { MapPin, Info } from 'lucide-react';
 import { useLocations } from '@/hooks/useLocations';
-import { Loading } from './Loading';
-import { useSmartContractInteractions } from '@/hooks/useSmartContractInteractions';
 import { LocationWithThumbnailAndDistance } from '../types/location';
-import { getNFTImage } from '@/lib/getLocations';
-import { generateAndUploadNFTMetaData } from '@/lib/pinata';
-import { useToast } from "@/components/ui/use-toast"
-import { useAuth } from '../contexts/AuthContext';
-import { updateUserData } from '@/app/actions/totalNFTs';
+import MintNFTButton from './mintNFTButton';
 
 export const NearestNFTSpots: React.FC = () => {
-  const { user } = useAuth();
-  const { mintNFT } = useSmartContractInteractions();
   const { userLocation, fetchNearestLocations } = useLocations();
   const [nearestLocations, setNearestLocations] = useState<LocationWithThumbnailAndDistance[]>([]);
-  const [isMinting, setIsMinting] = useState(false);
-  const [isMintingLocation, setIsMintingLocation] = useState<number>();
-  const [progress, setProgress] = useState(0);
-  const { toast } = useToast();
 
   useEffect(() =>  {
     const fetchLocations = async () => {
@@ -36,56 +23,6 @@ export const NearestNFTSpots: React.FC = () => {
     }
     fetchLocations()
   }, [userLocation])
-
-  const handleMintNFT = async (location: LocationWithThumbnailAndDistance) => {
-    if (!user) {
-      console.log('Please authenticate first');
-      return;
-    }
-
-    setIsMinting(true);
-    setIsMintingLocation(location.id)
-    setProgress(0);
-  
-    try {
-      setProgress(10);
-      const imageHash = await getNFTImage(location.id);
-      console.log('NFT image prepared:', imageHash);
-
-      setProgress(40);
-      const NFTMetadataHash = await generateAndUploadNFTMetaData(imageHash, location);
-      if (!NFTMetadataHash) {
-        throw new Error('NFT metadata hash is undefined');
-      }
-      console.log('NFT metadata generated:', NFTMetadataHash);
-
-      setProgress(70);
-      // ミント処理のトランザクションハッシュとミント後のユーザのNFT総数を取得
-      const { transactionHash, balanceNumber } = await mintNFT(user.auth_type, location.id, NFTMetadataHash);
-      console.log('NFT minted successfully! Transaction hash:', transactionHash);
-
-      setProgress(100);
-      toast({
-        title: "NFT Minted Successfully!",
-        description: `Your new NFT for ${location.name} has been minted with transaction hash: ${transactionHash}`,
-      })
-
-      // オンチェーンから取得したユーザのNFT総数Server Actionを使用してDBに更新
-      await updateUserData(balanceNumber);
-
-      return transactionHash;
-    } catch (error: any) {
-      console.error("NFT minting failed:", error);
-      toast({
-        title: "NFT Minting Failed",
-        description: error.message || "An unexpected error occurred. Please try again.",
-        variant: "destructive",
-      })
-    } finally {
-      setIsMinting(false)
-      setProgress(0)
-    }
-  };
 
   return (
     <section>
@@ -118,19 +55,7 @@ export const NearestNFTSpots: React.FC = () => {
                   <MapPin className="h-4 w-4 mr-1 text-green-400" />
                   <span>{location.distance.toFixed(2)} km</span>
                 </div>
-                <Button 
-                  onClick={() => handleMintNFT(location)}
-                  disabled={isMinting}
-                  className="w-full mt-2 bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded transition-colors duration-300"
-                >
-                  {(isMinting && isMintingLocation == location.id) ? 'Minting...' : 'GET NFT!'}
-                </Button>
-                {isMinting && (isMintingLocation == location.id) && (
-                  <div className="mt-2">
-                    <Progress value={progress} className="h-2 bg-gray-700 [&>div[role=progressbar]]:bg-blue-500" />
-                    <p className="text-sm text-gray-400 mt-1">{progress}% Complete</p>
-                  </div>
-                )}
+                <MintNFTButton location={location} />
                 <div className="absolute top-4 right-4 bg-blue-500 rounded-full p-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                   <Info className="h-4 w-4 text-white" />
                 </div>

--- a/frontend/src/app/components/mintNFTButton.tsx
+++ b/frontend/src/app/components/mintNFTButton.tsx
@@ -19,7 +19,6 @@ export default function MintNFTButton({ location }: MintNFTButtonProps) {
   const { user } = useAuth();
   const { mintNFT } = useSmartContractInteractions();
   const [isMinting, setIsMinting] = useState(false);
-  const [progress, setProgress] = useState(0);
   const { toast } = useToast();
 
   const handleMintNFT = async () => {
@@ -29,25 +28,20 @@ export default function MintNFTButton({ location }: MintNFTButtonProps) {
     }
 
     setIsMinting(true);
-    setProgress(0);
   
     try {
-      setProgress(10);
       const imageHash = await getNFTImage(location.id);
       console.log('NFT image prepared:', imageHash);
 
-      setProgress(40);
       const NFTMetadataHash = await generateAndUploadNFTMetaData(imageHash, location);
       if (!NFTMetadataHash) {
         throw new Error('NFT metadata hash is undefined');
       }
       console.log('NFT metadata generated:', NFTMetadataHash);
 
-      setProgress(70);
       const { transactionHash, balanceNumber } = await mintNFT(user.auth_type, location.id, NFTMetadataHash);
       console.log('NFT minted successfully! Transaction hash:', transactionHash);
 
-      setProgress(100);
       toast({
         title: "NFT Minted Successfully!",
         description: `Your new NFT for ${location.name} has been minted with transaction hash: ${transactionHash}`,
@@ -65,7 +59,6 @@ export default function MintNFTButton({ location }: MintNFTButtonProps) {
       })
     } finally {
       setIsMinting(false)
-      setProgress(0)
     }
   };
 
@@ -78,12 +71,6 @@ export default function MintNFTButton({ location }: MintNFTButtonProps) {
       >
         {isMinting ? 'Minting...' : 'GET NFT!'}
       </Button>
-      {isMinting && (
-        <div className="mt-2">
-          <Progress value={progress} className="h-2 bg-gray-700 [&>div[role=progressbar]]:bg-blue-500" />
-          <p className="text-sm text-gray-400 mt-1">{progress}% Complete</p>
-        </div>
-      )}
     </>
   );
 }

--- a/frontend/src/app/components/mintNFTButton.tsx
+++ b/frontend/src/app/components/mintNFTButton.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import React, { useState } from 'react';
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { useSmartContractInteractions } from '@/hooks/useSmartContractInteractions';
+import { LocationWithThumbnailAndDistance } from '../types/location';
+import { getNFTImage } from '@/lib/getLocations';
+import { generateAndUploadNFTMetaData } from '@/lib/pinata';
+import { useToast } from "@/components/ui/use-toast"
+import { useAuth } from '../contexts/AuthContext';
+import { updateUserData } from '@/app/actions/totalNFTs';
+
+interface MintNFTButtonProps {
+  location: LocationWithThumbnailAndDistance;
+}
+
+export default function MintNFTButton({ location }: MintNFTButtonProps) {
+  const { user } = useAuth();
+  const { mintNFT } = useSmartContractInteractions();
+  const [isMinting, setIsMinting] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const { toast } = useToast();
+
+  const handleMintNFT = async () => {
+    if (!user) {
+      console.log('Please authenticate first');
+      return;
+    }
+
+    setIsMinting(true);
+    setProgress(0);
+  
+    try {
+      setProgress(10);
+      const imageHash = await getNFTImage(location.id);
+      console.log('NFT image prepared:', imageHash);
+
+      setProgress(40);
+      const NFTMetadataHash = await generateAndUploadNFTMetaData(imageHash, location);
+      if (!NFTMetadataHash) {
+        throw new Error('NFT metadata hash is undefined');
+      }
+      console.log('NFT metadata generated:', NFTMetadataHash);
+
+      setProgress(70);
+      const { transactionHash, balanceNumber } = await mintNFT(user.auth_type, location.id, NFTMetadataHash);
+      console.log('NFT minted successfully! Transaction hash:', transactionHash);
+
+      setProgress(100);
+      toast({
+        title: "NFT Minted Successfully!",
+        description: `Your new NFT for ${location.name} has been minted with transaction hash: ${transactionHash}`,
+      })
+
+      await updateUserData(balanceNumber);
+
+      return transactionHash;
+    } catch (error: any) {
+      console.error("NFT minting failed:", error);
+      toast({
+        title: "NFT Minting Failed",
+        description: error.message || "An unexpected error occurred. Please try again.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsMinting(false)
+      setProgress(0)
+    }
+  };
+
+  return (
+    <>
+      <Button 
+        onClick={handleMintNFT}
+        disabled={isMinting}
+        className="bg-blue-600 hover:bg-blue-700 text-xs text-white"
+      >
+        {isMinting ? 'Minting...' : 'GET NFT!'}
+      </Button>
+      {isMinting && (
+        <div className="mt-2">
+          <Progress value={progress} className="h-2 bg-gray-700 [&>div[role=progressbar]]:bg-blue-500" />
+          <p className="text-sm text-gray-400 mt-1">{progress}% Complete</p>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/app/spots/[slug]/page.tsx
+++ b/frontend/src/app/spots/[slug]/page.tsx
@@ -61,9 +61,6 @@ export default async function TouristSpotDetail({ params }: { params: { slug: st
               Last updated: {new Date().toLocaleDateString()}
             </div>
             <ChatbotModal />
-            <Button size="lg" className="bg-green-600 hover:bg-green-700 text-white">
-              GET NFT!
-            </Button>
           </CardFooter>
         </Card>
       </main>

--- a/frontend/src/app/spots/[slug]/page.tsx
+++ b/frontend/src/app/spots/[slug]/page.tsx
@@ -4,7 +4,6 @@ import { ArrowLeft, MapPin, Mail } from 'lucide-react'
 import { Footer } from '../../components/Footer'
 import Header from '../../components/Header'
 import { getLocationBySlug } from '@/lib/getLocations'
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
 import { LocationDistance } from '@/app/components/LocationDistance'
 import { Suspense } from 'react'

--- a/frontend/src/app/spots/[slug]/page.tsx
+++ b/frontend/src/app/spots/[slug]/page.tsx
@@ -9,9 +9,10 @@ import { Card, CardContent, CardFooter } from "@/components/ui/card"
 import { LocationDistance } from '@/app/components/LocationDistance'
 import { Suspense } from 'react'
 import ChatbotModal from '@/app/components/ChatbotModal'
+import { LocationWithThumbnail } from '@/app/types/location'
 
 export default async function TouristSpotDetail({ params }: { params: { slug: string } }) {
-  const location = await getLocationBySlug(params.slug);
+  const location: LocationWithThumbnail = await getLocationBySlug(params.slug);
 
   return (
     <div className="flex flex-col min-h-screen bg-gradient-to-br from-gray-900 to-gray-800 text-white">
@@ -48,7 +49,7 @@ export default async function TouristSpotDetail({ params }: { params: { slug: st
 									 Loading...
 								</span>
 								}>
-									<LocationDistance lat={location.latitude} lon={location.longitude} />
+									<LocationDistance {...location} />
 								</Suspense>
               </div>
             </div>

--- a/frontend/src/app/types/location.ts
+++ b/frontend/src/app/types/location.ts
@@ -17,6 +17,10 @@ export type LocationImage = {
   is_primary: boolean
 }
 
+export interface LocationWithThumbnail extends Location {
+  thumbnail: string | null;
+}
+
 export interface LocationWithThumbnailAndDistance extends Location {
   thumbnail: string | null;
   distance: number;


### PR DESCRIPTION
## 概要
#65 

## やったこと
NFTミントボタンとミント処理をコンポーネント化してしてDashboardと観光地詳細どちらからもミントできるようにする