### PR TITLE
dashboardでmintをしたときのページ遷移を防ぐ

### DIFF
--- a/frontend/src/app/components/NearestNFTSpots.tsx
+++ b/frontend/src/app/components/NearestNFTSpots.tsx
@@ -16,7 +16,7 @@ export const NearestNFTSpots: React.FC = () => {
 
   useEffect(() =>  {
     const fetchLocations = async () => {
-      const locations: LocationWithThumbnailAndDistance[] | undefined = await fetchNearestLocations()
+      const locations: LocationWithThumbnailAndDistance[] = await fetchNearestLocations()
       if (locations) {
         setNearestLocations(locations)
       }

--- a/frontend/src/app/components/mintNFTButton.tsx
+++ b/frontend/src/app/components/mintNFTButton.tsx
@@ -64,7 +64,10 @@ export default function MintNFTButton({ location }: MintNFTButtonProps) {
   return (
     <>
       <Button 
-        onClick={handleMintNFT}
+        onClick={(event) => {
+          event.preventDefault();
+          handleMintNFT();
+        }}
         disabled={isMinting}
         className="bg-blue-600 hover:bg-blue-700 text-xs text-white"
       >

--- a/frontend/src/app/components/mintNFTButton.tsx
+++ b/frontend/src/app/components/mintNFTButton.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState } from 'react';
 import { Button } from "@/components/ui/button";
-import { Progress } from "@/components/ui/progress";
 import { useSmartContractInteractions } from '@/hooks/useSmartContractInteractions';
 import { LocationWithThumbnailAndDistance } from '../types/location';
 import { getNFTImage } from '@/lib/getLocations';

--- a/frontend/src/hooks/useLocations.ts
+++ b/frontend/src/hooks/useLocations.ts
@@ -53,15 +53,17 @@ export const useLocations = (nearestCount: number = 3) => {
   }, []);
 
   // 最寄りの場所を取得
-  const fetchNearestLocations = async () => {
+  const fetchNearestLocations = async (): Promise<LocationWithThumbnailAndDistance[]> => {
     if (userLocation.lat !== null && userLocation.lon !== null) {
       try {
         const fetchedNearestLocations = await getNearestLocations(userLocation.lat, userLocation.lon, nearestCount);
         return fetchedNearestLocations;
       } catch (error) {
         console.error('Failed to fetch nearest locations:', error);
+        return [];
       }
     }
+    return [];
   };
 
   return { userLocation, fetchNearestLocations };


### PR DESCRIPTION
## 概要
#72 

## 内容
Linkの子要素であるmintNFTButtonに`event.preventDefault()`を追加
LInkには別のイベントがなく、ページ遷移を止めたいだけなので`event.stopPropagation`は必要ない