### PR TITLE
チャットでユーザのメッセージを左づめにする

### DIFF
--- a/frontend/src/app/components/ChatbotModal.tsx
+++ b/frontend/src/app/components/ChatbotModal.tsx
@@ -107,7 +107,7 @@ export default function ChatbotModal({ location }: { location: LocationWithThumb
                           🤖
                         </div>
                       )}
-                      <div className={`max-w-[75%] px-3 py-2 rounded-lg text-sm sm:text-base ${message.role === 'user' ? 'bg-blue-600 text-white text-right' : 'bg-gray-700 text-white'}`}>
+                      <div className={`max-w-[75%] px-3 py-2 rounded-lg text-sm sm:text-base ${message.role === 'user' ? 'bg-blue-600 text-white' : 'bg-gray-700 text-white'} mx-1`}>
                         {message.content}
                       </div>
                     </div>


### PR DESCRIPTION
## 概要
#84 

## 修正後
<img width="1508" alt="スクリーンショット 2024-10-03 20 55 17" src="https://github.com/user-attachments/assets/34cbd60f-aedc-424e-bffc-7e65a5764174">
