### PR TITLE
Web3AuthユーザにもNFT発行を可能にする

### DIFF
--- a/frontend/src/app/actions/rpcUrl.ts
+++ b/frontend/src/app/actions/rpcUrl.ts
@@ -1,0 +1,6 @@
+'use server'
+
+export async function getRpcUrl() {
+  const rpcUrl = `https://eth-sepolia.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`;
+  return rpcUrl;
+}

--- a/frontend/src/app/contexts/AuthContext.tsx
+++ b/frontend/src/app/contexts/AuthContext.tsx
@@ -5,8 +5,9 @@ import { BrowserProvider } from 'ethers';
 import { User, AuthMethod, AuthContextType } from '../types/auth';
 import { ExtendedWindow } from '../types/ethere';
 import { Loading } from '../components/Loading';
-import { Web3Auth } from "@web3auth/modal";
 import { useRouter } from 'next/navigation';
+import { initWeb3Auth, getWeb3AuthAccountInfo } from '@/lib/web3auth';
+import { Web3Auth } from "@web3auth/modal";
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
@@ -21,10 +22,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setIsLoading(true);
 
       try {
-        const web3authModule = await import('@/lib/web3auth');
-        const web3authInstance = web3authModule.web3auth;
-
-        await web3authInstance.initModal();
+        const web3authInstance = await initWeb3Auth();
         setWeb3auth(web3authInstance);
 
         await checkAuth();

--- a/frontend/src/lib/web3auth.ts
+++ b/frontend/src/lib/web3auth.ts
@@ -2,37 +2,44 @@ import { Web3Auth } from "@web3auth/modal";
 import { CHAIN_NAMESPACES, WEB3AUTH_NETWORK } from "@web3auth/base";
 import { EthereumPrivateKeyProvider } from "@web3auth/ethereum-provider";
 import { ethers } from 'ethers';
+import { getRpcUrl } from "@/app/actions/rpcUrl";
 
-const chainConfig = {
+// チェーン設定を関数として定義
+const getChainConfig = async () => ({
   chainNamespace: CHAIN_NAMESPACES.EIP155,
   chainId: "0xaa36a7",
-  rpcTarget: "https://rpc.ankr.com/eth_sepolia",
+  rpcTarget: await getRpcUrl(),
   displayName: "Ethereum Sepolia Testnet",
   blockExplorerUrl: "https://sepolia.etherscan.io",
   ticker: "ETH",
   tickerName: "Ethereum",
   logo: "https://cryptologos.cc/logos/ethereum-eth-logo.png",
   useCoreKitKey: true,
-};
-const privateKeyProvider = new EthereumPrivateKeyProvider({
-  config: { chainConfig },
 });
 
-const clientId = process.env.NEXT_PUBLIC_WEB3AUTH_CLIENT_ID;
-
-export const web3auth = new Web3Auth({
-  clientId: clientId || '',
-  web3AuthNetwork: WEB3AUTH_NETWORK.SAPPHIRE_MAINNET,
-  privateKeyProvider,
-});
-
+// Web3Auth初期化関数
 export const initWeb3Auth = async (): Promise<Web3Auth> => {
-  const web3authModule = await import('@/lib/web3auth');
-  const web3authInstance = web3authModule.web3auth;
-  await web3authInstance.initModal();
-  return web3authInstance;
+  const chainConfig = await getChainConfig();
+  const privateKeyProvider = new EthereumPrivateKeyProvider({
+    config: { chainConfig },
+  });
+
+  const clientId = process.env.NEXT_PUBLIC_WEB3AUTH_CLIENT_ID;
+  if (!clientId) {
+    throw new Error("WEB3AUTH_CLIENT_ID is not defined");
+  }
+
+  const web3auth = new Web3Auth({
+    clientId,
+    web3AuthNetwork: WEB3AUTH_NETWORK.SAPPHIRE_MAINNET,
+    privateKeyProvider,
+  });
+
+  await web3auth.initModal();
+  return web3auth;
 };
 
+// Web3Auth接続関数
 export const connectWeb3Auth = async (web3auth: Web3Auth) => {
   const web3authProvider = await web3auth.connect();
   if (!web3authProvider) {
@@ -41,15 +48,19 @@ export const connectWeb3Auth = async (web3auth: Web3Auth) => {
   return new ethers.BrowserProvider(web3authProvider);
 };
 
+// アカウント情報取得関数
 export const getWeb3AuthAccountInfo = async (web3auth: Web3Auth) => {
-  const user = await web3auth.getUserInfo();
-  const ethersProvider = await connectWeb3Auth(web3auth);
-  const signer = await ethersProvider.getSigner();
-  const address = await signer.getAddress();
-  const balance = await ethersProvider.getBalance(address);
-  const balanceInEther = ethers.formatEther(balance);
-  console.log("User Info:", user);
-  console.log("Address:", address);
-  console.log("Signer:", signer);
-  console.log("Balance:", balanceInEther);
+  try {
+    const user = await web3auth.getUserInfo();
+    const ethersProvider = await connectWeb3Auth(web3auth);
+    const signer = await ethersProvider.getSigner();
+    const address = await signer.getAddress();
+    const balance = await ethersProvider.getBalance(address);
+    const balanceInEther = ethers.formatEther(balance);
+
+    return { user, address, signer, balanceInEther };
+  } catch (error) {
+    console.error("Error getting account info:", error);
+    throw error;
+  }
 };

--- a/frontend/src/lib/web3auth.ts
+++ b/frontend/src/lib/web3auth.ts
@@ -1,6 +1,7 @@
 import { Web3Auth } from "@web3auth/modal";
 import { CHAIN_NAMESPACES, WEB3AUTH_NETWORK } from "@web3auth/base";
 import { EthereumPrivateKeyProvider } from "@web3auth/ethereum-provider";
+import { ethers } from 'ethers';
 
 const chainConfig = {
   chainNamespace: CHAIN_NAMESPACES.EIP155,
@@ -24,3 +25,31 @@ export const web3auth = new Web3Auth({
   web3AuthNetwork: WEB3AUTH_NETWORK.SAPPHIRE_MAINNET,
   privateKeyProvider,
 });
+
+export const initWeb3Auth = async (): Promise<Web3Auth> => {
+  const web3authModule = await import('@/lib/web3auth');
+  const web3authInstance = web3authModule.web3auth;
+  await web3authInstance.initModal();
+  return web3authInstance;
+};
+
+export const connectWeb3Auth = async (web3auth: Web3Auth) => {
+  const web3authProvider = await web3auth.connect();
+  if (!web3authProvider) {
+    throw new Error("Failed to connect to web3auth");
+  }
+  return new ethers.BrowserProvider(web3authProvider);
+};
+
+export const getWeb3AuthAccountInfo = async (web3auth: Web3Auth) => {
+  const user = await web3auth.getUserInfo();
+  const ethersProvider = await connectWeb3Auth(web3auth);
+  const signer = await ethersProvider.getSigner();
+  const address = await signer.getAddress();
+  const balance = await ethersProvider.getBalance(address);
+  const balanceInEther = ethers.formatEther(balance);
+  console.log("User Info:", user);
+  console.log("Address:", address);
+  console.log("Signer:", signer);
+  console.log("Balance:", balanceInEther);
+};


### PR DESCRIPTION
## 概要
RPC URLにAlchemyを使用することでWeb3Authユーザでもトランザクション実行できるようにする