### PR TITLE
Web3Auth初期認証時にプロフィール情報を取得する

### DIFF
--- a/frontend/src/app/contexts/AuthContext.tsx
+++ b/frontend/src/app/contexts/AuthContext.tsx
@@ -8,6 +8,8 @@ import { Loading } from '../components/Loading';
 import { useRouter } from 'next/navigation';
 import { initWeb3Auth, getWeb3AuthAccountInfo } from '@/lib/web3auth';
 import { Web3Auth } from "@web3auth/modal";
+import { supabase } from '@/lib/supabase';
+import axios from 'axios';
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
@@ -79,11 +81,85 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const { user: newUser } = await response.json();
 
       setUser(newUser);
+      await setWeb3AuthUserProfile(newUser)
 
       return newUser;
     } catch (error) {
+      await logout()
       console.error(`Error during ${method} login:`, error);
       throw error;
+    }
+  };
+
+  const setWeb3AuthUserProfile = async (user: User) => {
+    try {
+      const { data: existingUser, error: fetchError } = await supabase
+        .from('user_profiles')
+        .select('name, email')
+        .eq('user_id', user.id)
+        .single();
+
+      if (fetchError) throw fetchError;
+      console.log(existingUser)
+
+      // nameとemailがnull以外の場合はreturn
+      if (existingUser && (existingUser.name !== null || existingUser.email !== null)) {
+        console.log("nameかemailがセットされてます")
+        return;
+      }
+
+      const userInfo = await web3auth?.getUserInfo();
+      if (userInfo) {
+        console.log(userInfo)
+
+        const avatar_url = await uploadAvatarFromUrl(userInfo.profileImage || '/images/no-user-icon.png', user.id)
+
+        const { error } = await supabase
+          .from('user_profiles')
+          .update({ name: userInfo.name, email: userInfo.email, avatar_url: avatar_url })
+          .eq('user_id', user.id)
+          .single()
+        
+        if (error) throw error;
+      }
+		} catch (error) {
+      await logout()
+			console.log(`Failed to update user profile${error}`);
+		}
+  }
+
+  const uploadAvatarFromUrl = async (url: string, userId: number): Promise<string | null> => {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) throw new Error('Failed to fetch the image');
+      const blob = await response.blob();
+  
+      const fileExtension = blob.type.split('/')[1];
+      const fileName = `${String(userId)}_avatar.${fileExtension}`;
+
+      console.log(fileName)
+  
+      // blobをFileオブジェクトに変換
+      const file = new File([blob], fileName, { type: blob.type });
+  
+      const { error } = await supabase.storage
+        .from('avatars')
+        .upload(fileName, file, { upsert: true });
+  
+      if (error) {
+        console.error('Error uploading avatar:', error);
+        return null;
+      }
+  
+      // 公開URLを取得
+      const { data } = supabase.storage
+        .from('avatars')
+        .getPublicUrl(fileName);
+      
+      return data.publicUrl;
+    } catch (error) {
+      console.error('Error in avatar upload process:', error);
+      return null;
     }
   };
 


### PR DESCRIPTION
## 概要
#81 

## 詳細
- `name`, `email`, `avatar_url`をソーシャルアカウントから取得して自動的に`user_profiles`に保存する