### PR TITLE
リーダボードからプロフィールへのリンク

### DIFF
--- a/frontend/src/app/components/ChatbotModal.tsx
+++ b/frontend/src/app/components/ChatbotModal.tsx
@@ -92,7 +92,7 @@ export default function ChatbotModal({ location }: { location: LocationWithThumb
                   <div key={index} className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'} mb-4`}>
                     <div className={`flex items-end ${message.role === 'user' ? 'flex-row-reverse' : ''} max-w-full`}>
                       {message.role === 'user' ? (
-                        <Link href={`/profile/${user?.wallet_address}`} className="relative w-8 h-8 sm:w-10 sm:h-10 rounded-full overflow-hidden ml-2 flex-shrink-0">
+                        <Link href={`/profile/${user?.id}`} className="relative w-8 h-8 sm:w-10 sm:h-10 rounded-full overflow-hidden ml-2 flex-shrink-0">
                           <Image
                             src={userProfile?.avatar_url || "/images/no-user-icon.png"}
                             alt="User Avatar"

--- a/frontend/src/app/components/Header.tsx
+++ b/frontend/src/app/components/Header.tsx
@@ -43,7 +43,7 @@ const Header: React.FC = () => {
           </h1>
         </Link>
         <div className="flex items-center space-x-4">
-          <Link href={`/profile/${user.wallet_address}`} className="flex items-center space-x-2">
+          <Link href={`/profile/${user.id}`} className="flex items-center space-x-2">
             <div className="text-sm font-medium text-gray-300">{sliceWalletAddress(user.wallet_address, 4, 3)}</div>
             <div className="relative w-8 h-8 rounded-full overflow-hidden">
               <Image

--- a/frontend/src/app/components/LeaderboardCard.tsx
+++ b/frontend/src/app/components/LeaderboardCard.tsx
@@ -49,41 +49,40 @@ export const LeaderboardCard: React.FC = () => {
     fetchData();
   }, [user]);
 
-  return (
+	return (
 		<Card className="bg-gray-800 border-gray-700 overflow-hidden">
 			<CardContent className="p-6">
 				<h3 className="text-2xl font-bold text-blue-400 mb-4">NFTリーダーボード</h3>
 				<div className="space-y-4">
 				{userRanking?.map((user, index) => (
-					<div
-						key={user.user_id}
-						className={`p-4 rounded-lg flex items-center justify-between ${
-							user.user_id ===  userId? "mt-4 bg-gray-700 border-t-2 border-blue-500" : "bg-gray-700"
-						}`}
-					>
-						<div className="flex items-center space-x-4">
-							<span className="font-bold text-lg">{index + 1}</span>
-							{getRankIcon(index + 1)}
-							<div className="relative w-8 h-8 rounded-full overflow-hidden">
-							<Image
-								src={ user.avatar_url || "/images/no-user-icon.png"}
-								alt="User Avatar"
-								style={{ objectFit: 'cover' }}
-								className="transition-opacity duration-300 group-hover:opacity-50"
-								fill
-								sizes="128px"
-							/>
-						</div>
-						<Link href={`/profile/${user.user_id}`}>
-							<p className="font-medium text-white">{user.name}</p>
-						</Link>
-						</div>
+					<Link href={`/profile/${user.user_id}`} key={user.user_id} className="block">
 						<div
-							className="font-bold text-blue-400"
+							className={`p-4 rounded-lg flex items-center justify-between ${
+								user.user_id ===  userId? "mt-4 bg-gray-700 border-t-2 border-blue-500" : "bg-gray-700"
+							}`}
 						>
-							{user.total_nfts} NFTs
+							<div className="flex items-center space-x-4">
+								<span className="font-bold text-lg">{index + 1}</span>
+								{getRankIcon(index + 1)}
+								<div className="relative w-8 h-8 rounded-full overflow-hidden">
+								<Image
+									src={ user.avatar_url || "/images/no-user-icon.png"}
+									alt="User Avatar"
+									style={{ objectFit: 'cover' }}
+									className="transition-opacity duration-300 group-hover:opacity-50"
+									fill
+									sizes="128px"
+								/>
+							</div>
+							<p className="font-medium text-white">{user.name}</p>
+							</div>
+							<div
+								className="font-bold text-blue-400"
+							>
+								{user.total_nfts} NFTs
+							</div>
 						</div>
-					</div>
+					</Link>
 				))}
 			</div>
 			</CardContent>

--- a/frontend/src/app/components/LeaderboardCard.tsx
+++ b/frontend/src/app/components/LeaderboardCard.tsx
@@ -12,7 +12,7 @@ type userRanking = { rank: number; user_id: number; name: string; avatar_url: st
 export const LeaderboardCard: React.FC = () => {
 	const { user } = useAuth();
 	const userId = user?.id
-	const [userRanking, setUserRanking] = useState<userRanking>(undefined)
+	const [userRanking, setUserRanking] = useState<userRanking>()
 
   const getRankIcon = (rank: number) => {
     switch (rank) {

--- a/frontend/src/app/components/LeaderboardCard.tsx
+++ b/frontend/src/app/components/LeaderboardCard.tsx
@@ -31,7 +31,7 @@ export const LeaderboardCard: React.FC = () => {
 				}
 		})
 		}
-	});
+	}, [user]);
 
   return (
 		<Card className="bg-gray-800 border-gray-700 overflow-hidden">

--- a/frontend/src/app/components/LeaderboardCard.tsx
+++ b/frontend/src/app/components/LeaderboardCard.tsx
@@ -58,7 +58,7 @@ export const LeaderboardCard: React.FC = () => {
 					<Link href={`/profile/${user.user_id}`} key={user.user_id} className="block">
 						<div
 							className={`p-4 rounded-lg flex items-center justify-between ${
-								user.user_id ===  userId? "mt-4 bg-gray-700 border-t-2 border-blue-500" : "bg-gray-700"
+								user.user_id ===  userId? "mt-4 bg-gray-700 border-2 border-blue-500" : "bg-gray-700"
 							}`}
 						>
 							<div className="flex items-center space-x-4">

--- a/frontend/src/app/profile/[id]/edit/page.tsx
+++ b/frontend/src/app/profile/[id]/edit/page.tsx
@@ -93,7 +93,7 @@ export default function EditProfilePage() {
         };
         await updateProfile(updatedProfile);
         
-        router.push(`/profile/${user?.wallet_address}`)
+        router.push(`/profile/${user?.id}`)
       } else {
         console.error('User profile not found');
       }

--- a/frontend/src/app/profile/[id]/page.tsx
+++ b/frontend/src/app/profile/[id]/page.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
+import { useParams } from 'next/navigation'
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Mail, Edit, Image as ImageIcon } from 'lucide-react'
@@ -16,11 +17,16 @@ import { Loading } from '@/app/components/Loading'
 export default function UserProfilePage() {
   const { user } = useAuth();
   const router = useRouter();
-  const { userProfile } = useUserProfile(user?.id);
+  const { id } = useParams();
+  const { userProfile } = useUserProfile(Number(id));
 
   if (!userProfile) {
     return <Loading />;
   }
+
+  // 自分のプロフィールかどうかを判別
+  // Editボタンの表示を制御
+  const isOwnProfile = (user?.id === Number(id));
 
   return (
     <div className="flex flex-col min-h-screen bg-gradient-to-br from-gray-900 to-gray-800 text-white">
@@ -33,7 +39,7 @@ export default function UserProfilePage() {
                 <div className="relative w-32 h-32 rounded-full overflow-hidden">
                   <Image
                     src={userProfile.avatar_url || "/images/no-user-icon.png"}
-                    alt={user?.wallet_address || "no wallet address"}
+                    alt={"user_avatar"}
                     fill
                     sizes="200px"
                     style={{ objectFit: 'cover' }}
@@ -45,19 +51,21 @@ export default function UserProfilePage() {
                   <div className="flex flex-col md:flex-row justify-between items-center mb-2 gap-4">
                     <h1 className="text-3xl font-bold text-blue-400">{userProfile.name || "No Name"}</h1>
                     <div className="flex gap-2">
-                      <Button 
-                        className="bg-gray-700 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded transition-colors duration-300"
-                        onClick={() => router.push(`/profile/${user?.wallet_address}/edit`)}  // 編集ページへのナビゲーション
-                      >
-                        <Edit className="mr-2 h-4 w-4" />
-                        Edit Profile
-                      </Button>
-                      <Link href="/nfts" passHref>
+                      {isOwnProfile && (
+                        <Button 
+                          className="bg-gray-700 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded transition-colors duration-300"
+                          onClick={() => router.push(`/profile/${id}/edit`)}
+                        >
+                          <Edit className="mr-2 h-4 w-4" />
+                          Edit Profile
+                        </Button>
+                      )}
+                      <Link href={`/nfts/${id}`} passHref>
                         <Button 
                           className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded transition-colors duration-300"
                         >
                           <ImageIcon className="mr-2 h-4 w-4" />
-                          My NFTs
+                          NFTs
                         </Button>
                       </Link>
                     </div>

--- a/frontend/src/lib/getNFTRanking.ts
+++ b/frontend/src/lib/getNFTRanking.ts
@@ -39,3 +39,21 @@ export async function getTopNFTHolders(userId: number) {
     return null
   }
 }
+
+// user_idからウォレットアドレスを取得するメソッド
+export async function getWalletAddress(userId: number) {
+  try {
+    const { data, error } = await supabase
+      .from('users')
+      .select('wallet_address')
+      .eq('id', userId)
+      .single()
+
+    if (error) throw error;
+
+    return data.wallet_address;
+  } catch (error) {
+    console.error('Error fetching user wallet address:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## 概要
#102 

## 修正内容

- [ ] ユーザプロフィールのURLを`wallet_address`ではなく、`id`にすることで他の人のプロフィールを表示しやすくする

## 実装画面
https://github.com/user-attachments/assets/ebfaa79e-a690-45d8-8dcb-d37cedeebbf2

