### PR TITLE
NFTリーダーボードのNFT数を動的に更新する

### DIFF
--- a/frontend/src/app/actions/userProgress.ts
+++ b/frontend/src/app/actions/userProgress.ts
@@ -8,7 +8,7 @@ import { cookies } from 'next/headers'
 const JWT_SECRET = process.env.JWT_SECRET!
 
 // ブラウザのCookieからユーザーのIDを取得する関数
-function getUserIdFromToken(): string {
+export async function getUserIdFromToken(): Promise<string> {
   const token = cookies().get('auth_token')?.value
 
   if (!token) {
@@ -61,7 +61,7 @@ function calculateProgress(xp: number, level: number): number {
 
 // SupabaseからユーザーのNFT総数を取得する関数
 export async function getUserData() {
-  const userId = getUserIdFromToken()
+  const userId = await getUserIdFromToken()
 
   try {
     const { data, error } = await supabase
@@ -85,7 +85,7 @@ export async function getUserData() {
 
 // ユーザーのNFT総数を更新する関数(呼ばれるたびにdashboardのユーザーNFT総数を再検証)
 export async function updateUserData(newTotalNFTs: number) {
-  const userId = getUserIdFromToken()
+  const userId = await getUserIdFromToken()
   
   const xp = calculateXP(newTotalNFTs);
   const newLevel = calculateLevel(xp);

--- a/frontend/src/app/components/LeaderboardCard.tsx
+++ b/frontend/src/app/components/LeaderboardCard.tsx
@@ -40,8 +40,8 @@ export const LeaderboardCard: React.FC = async () => {
 							}`}
 						>
 							<div className="flex items-center space-x-4">
-								<span className="font-bold text-lg">{index + 1}</span>
-								{getRankIcon(index + 1)}
+								<span className="font-bold text-lg">{user.rank}</span>
+								{getRankIcon(user.rank)}
 								<div className="relative w-8 h-8 rounded-full overflow-hidden">
 								<Image
 									src={ user.avatar_url || "/images/no-user-icon.png"}

--- a/frontend/src/app/components/LeaderboardCard.tsx
+++ b/frontend/src/app/components/LeaderboardCard.tsx
@@ -1,12 +1,9 @@
-"use client"
-
-import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Trophy, Medal, Star } from 'lucide-react';
 import Image from 'next/image';
-import { useAuth } from "../contexts/AuthContext";
 import { getTopNFTHolders } from "@/lib/getNFTRanking";
 import Link from "next/link";
+import { getUserIdFromToken } from "../actions/userProgress";
 
 type UserRanking = {
   rank: number;
@@ -16,10 +13,10 @@ type UserRanking = {
   total_nfts: number;
 };
 
-export const LeaderboardCard: React.FC = () => {
-	const { user } = useAuth();
-	const userId = user?.id
-	const [userRanking, setUserRanking] = useState<UserRanking[]>([]);
+export const LeaderboardCard: React.FC = async () => {
+	const userId = await getUserIdFromToken();
+  const data = await getTopNFTHolders(Number(userId));
+  const userRanking: UserRanking[] = data ? data.ranking : [];
 
   const getRankIcon = (rank: number) => {
     switch (rank) {
@@ -30,19 +27,6 @@ export const LeaderboardCard: React.FC = () => {
     }
   };
 
-	useEffect(() => {
-    const fetchData = async () => {
-      if (user) {
-        const data = await getTopNFTHolders(user.id);
-        // 取得したデータをuserRankingにセット
-        if (data) {
-          setUserRanking(data.ranking);
-        }
-      }
-    };
-    fetchData();
-  }, [user]);
-
 	return (
 		<Card className="bg-gray-800 border-gray-700 overflow-hidden">
 			<CardContent className="p-6">
@@ -52,7 +36,7 @@ export const LeaderboardCard: React.FC = () => {
 					<Link href={`/profile/${user.user_id}`} key={user.user_id} className="block">
 						<div
 							className={`p-4 rounded-lg flex items-center justify-between ${
-								user.user_id ===  userId? "mt-4 bg-gray-700 border-2 border-blue-500" : "bg-gray-700"
+								user.user_id ===  Number(userId)? "mt-4 bg-gray-700 border-2 border-blue-500" : "bg-gray-700"
 							}`}
 						>
 							<div className="flex items-center space-x-4">
@@ -70,12 +54,12 @@ export const LeaderboardCard: React.FC = () => {
 							</div>
 							<p className="font-medium text-white">{user.name}</p>
 							</div>
-							<div
+							<Link
+								href={`/nfts/${user.user_id}`}
 								className="font-bold text-blue-400 cursor-pointer"
-								onClick={() => window.location.href = `/nfts/${user.user_id}`}
 							>
 								{user.total_nfts} NFTs
-							</div>
+							</Link>
 						</div>
 					</Link>
 				))}

--- a/frontend/src/app/components/mintNFTButton.tsx
+++ b/frontend/src/app/components/mintNFTButton.tsx
@@ -11,6 +11,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { updateUserData } from '@/app/actions/userProgress';
 import { motion } from 'framer-motion';
 import { Award } from 'lucide-react'
+import { getTopNFTHolders } from '@/lib/getNFTRanking';
 
 export default function MintNFTButton({ location }: {location: LocationWithThumbnailAndDistance}) {
   const { user } = useAuth();
@@ -57,6 +58,7 @@ export default function MintNFTButton({ location }: {location: LocationWithThumb
       })
 
       await updateUserData(balanceNumber);
+      await getTopNFTHolders(user.id)
 
       return transactionHash;
     } catch (error: any) {

--- a/frontend/src/lib/getNFTRanking.ts
+++ b/frontend/src/lib/getNFTRanking.ts
@@ -1,4 +1,7 @@
+'use server'
+
 import { supabase } from '@/lib/supabase'
+import { revalidatePath } from 'next/cache'
 
 // NFT保持数トップ5とユーザのランキングを取得する
 export async function getTopNFTHolders(userId: number) {
@@ -33,6 +36,7 @@ export async function getTopNFTHolders(userId: number) {
       ranking.push(userRankData)
     }
 
+    revalidatePath('/dashboard')
     return { ranking }
 
   } catch (error: any) {

--- a/frontend/src/lib/getNFTRanking.ts
+++ b/frontend/src/lib/getNFTRanking.ts
@@ -1,5 +1,6 @@
 import { supabase } from '@/lib/supabase'
 
+// NFT保持数トップ5とユーザのランキングを取得する
 export async function getTopNFTHolders(userId: number) {
   try {
     const { data: allUsersData, error: allUsersError } = await supabase


### PR DESCRIPTION
## 概要
`dashboard`のリーダーボードでNFT数とランキングを動的に表示する

## 実装画面

https://github.com/user-attachments/assets/f2e1e2e9-a46b-404d-a913-4381607aa952
